### PR TITLE
Refactor: Improve save/load for all learning modes and upgrade Brain.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
         <!-- Tailwind CSS CDN -->
         <script src="https://cdn.tailwindcss.com"></script>
         <!-- Brain.js CDN -->
-        <script src="https://cdn.jsdelivr.net/npm/brain.js@2.0.0-beta.2/dist/brain-browser.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/brain.js@2.0.0-beta.24/dist/brain-browser.min.js"></script>
         <!-- Font Awesome for icons -->
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
         <style>

--- a/neural_network.js
+++ b/neural_network.js
@@ -390,7 +390,8 @@ class NeuralNetworkManager {
         try {
             return {
                 modelType: metadata.type || 'brain.js_network', // Indicate the type of network (e.g., genetic, qlearning)
-                network: network.toJSON() // Only save the neural network's internal state
+                network: network.toJSON(), // Only save the neural network's internal state
+                brainJsVersion: brain.version // Add Brain.js version
             };
         } catch (error) {
             console.error('Error saving network:', error);
@@ -405,11 +406,20 @@ class NeuralNetworkManager {
         if (!data || !data.network) return null;
 
         try {
+            if (data.brainJsVersion) {
+                console.log('Loading model created with Brain.js version:', data.brainJsVersion);
+                if (brain.version && data.brainJsVersion !== brain.version) {
+                    console.warn('Brain.js version mismatch. Loaded model version:', data.brainJsVersion, 'Current library version:', brain.version);
+                }
+            }
+
             const network = this.createNetwork();
             network.fromJSON(data.network);
             return {
                 network: network,
-                metadata: data.metadata || {} // Keep metadata for compatibility, though not used in save now
+                // Keep metadata for compatibility, though not used in save now.
+                // Include brainJsVersion in returned metadata if it was present in the loaded data.
+                metadata: { ...(data.metadata || {}), brainJsVersion: data.brainJsVersion }
             };
         } catch (error) {
             console.error('Error loading network:', error);


### PR DESCRIPTION
This commit addresses issues with the model saving and loading functionality across different learning algorithms and updates the Brain.js library.

Key changes:
- Corrected `ImitationLearning.loadModel` to prevent loaded model structure from being overwritten by UI parameters. Only the learning rate is updated from the UI post-load.
- Corrected `ActorCriticLearning.loadModel` similarly to preserve loaded actor/critic network structures and weights. Training-related hyperparameters are now selectively updated from UI post-load.
- Upgraded Brain.js from `2.0.0-beta.2` to `2.0.0-beta.24` by updating the CDN link in `index.html`.
- Simplified `ActorCriticLearning.cloneNetwork` to rely on the more robust `toJSON/fromJSON` expected in the newer Brain.js version.
- Added `brainJsVersion` to all saved model JSONs (`NeuralNetworkManager`, `ImitationLearning`, `ActorCriticLearning`) to aid future debugging.
- Loading functions now log the saved `brainJsVersion` and warn if it mismatches the current library version.
- Verified and confirmed the save/load logic for Genetic Algorithm and Q-Learning, which primarily use `NeuralNetworkManager`.

These changes aim to make the model persistence feature reliable and robust across all implemented learning strategies.